### PR TITLE
Fix errors with 'puppet module list'

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,8 +8,8 @@
   "project_page": "https://github.com/beergeek/puppet_master_manager",
   "issues_url": "https://github.com/beergeek/puppet_master_manager/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
-    {"name":"puppetlabs/pe_postgresql","version_requirement":"3.4.x"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs/pe_postgresql","version_requirement":"3.4.x"}
   ]
 }
 


### PR DESCRIPTION
This commit fixes two errors when running "puppet module list":
1) Missing dependency 'puppetlabs-stdlib'
2) Version question marks
